### PR TITLE
Update KRE-v1.1.md

### DIFF
--- a/accepted/KRE-v1.1.md
+++ b/accepted/KRE-v1.1.md
@@ -43,10 +43,11 @@ If (s_1 + s_2  > 0.90) or (s_1 > 0.5):
     Else:
         s_1' = s_1
     If s_1' + s_2  > 0.90 then:
-        s_2 = s_2 / (s_1+s_2) * 0.9
-
-    s_1’ = minimum(s_1 / (s_1+s_2) * 0.9, s_1')
-    If s_1’ == s_1 / (s_1 + s_2) * 0.9:
+        s_2' = s_2 / (s_1+s_2) * 0.9
+    Else:
+    	s_2' = s_2
+    s_1’ = minimum(s_1' / (s_1'+s_2) * 0.9, s_1')
+    If s_2’ != s_2:
         For i = 3 to n:
             s_i’ = s_i / (sum from i = 3 to n of s_i) * 0.1
     Else:
@@ -64,7 +65,7 @@ Reasoning: Clause does not apply
 
 **Example 2:**  
 Payout shares before clause: `{0.90, 0.05, 0.03, 0.02}`  
-Payout shares after clause: `{0.663, 0.183, 0.11, 0.073}`  
+Payout shares after clause: `{0.633, 0.183, 0.11, 0.073}`  
 Reasoning: 2.i.1 applies
 
 **Example 3:**  


### PR DESCRIPTION
Updated typo in monopoly clause pseudocode. When coding up the pseudocode Example 4 produced a wrong result using the code as written. This has been fixed.
Also fixed a typo in the output of Example 2.